### PR TITLE
Use constant for triangles

### DIFF
--- a/src/ui/drag_and_drop_slot.rs
+++ b/src/ui/drag_and_drop_slot.rs
@@ -105,7 +105,17 @@ fn generate_cooldown_mesh(cooldown: f32, content_rect: egui::Rect) -> egui::epai
         content_rect.min.y,
     );
 
-    let segments = cooldown / 0.125f32;
+    /*
+     * Triangles:
+     * _______
+     * |\ | /|
+     * |_\|/_|
+     * | /|\ |
+     * |/ | \|
+     * -------
+     */ 
+    const TRIANGLES_COUNT: f32 = 8.0;
+    let segments = cooldown * TRIANGLES_COUNT;
     let num_segments = segments.trunc() as u32;
     for segment_id in 0..num_segments {
         mesh.add_triangle(0, segment_id + 1, segment_id + 2);


### PR DESCRIPTION
Your mesh implementation for cooldown is great!
In this PR I moved `0.125` (1/8) into a constant and instead of division I just multiply by 8 (number of triangles). Maybe you find it useful too :)